### PR TITLE
[FIX]: Generate API key URL

### DIFF
--- a/tabs/index.tsx
+++ b/tabs/index.tsx
@@ -63,7 +63,7 @@ function IndexPage(): ReactElement {
       <h3>🟢 | First we need to generate a OpenAI api Token.</h3>
       <p>
         <a
-          href="https://platform.openai.com/overview"
+          href="https://platform.openai.com/account/api-keys"
           target="_blank"
           rel="noreferrer">
           Click here


### PR DESCRIPTION
"Click here" text redirects to the overview page. It might be hard for not tech-savvy people to find the page where they can view their api keys. That's why I replaced it with the link that redirects users directly to the api keys page.